### PR TITLE
Support helm for completion when clocking in to recent tasks

### DIFF
--- a/org-mru-clock.el
+++ b/org-mru-clock.el
@@ -93,7 +93,8 @@ has enough entries."
 
 (defcustom org-mru-clock-completing-read completing-read-function
   "Like `completing-read-function', but only used in `org-mru-clock' functions.
-Popular choices include `ivy-completing-read' and `ido-completing-read'."
+Popular choices include `ivy-completing-read', `ido-completing-read', and
+`helm-comp-read'"
   :group 'org-mru-clock
   :type 'function)
 
@@ -256,19 +257,26 @@ filled first.  Optional argument N as in `org-mru-clock'."
 Support extra actions if we're using ivy.
 PROMPT and COLLECTION as in `completing-read',
 ACTION and CALLER as in `ivy-read'."
-  (if (eq org-mru-clock-completing-read #'ivy-completing-read)
-      (ivy-read prompt
-                collection
-                :action action
-                :require-match t
-                :caller caller)
+  (cond
+   ((eq org-mru-clock-completing-read #'ivy-completing-read)
+    (ivy-read prompt
+              collection
+              :action action
+              :require-match t
+              :caller caller))
+   ((eq org-mru-clock-completing-read #'helm-comp-read)
     (funcall action
              (assoc (funcall org-mru-clock-completing-read
                              prompt
-                             (mapcar #'car collection)
-                             nil
-                             'require-match)
-                    collection))))
+                             (mapcar #'car collection))
+                    collection)))
+   (t (funcall action
+               (assoc (funcall org-mru-clock-completing-read
+                               prompt
+                               (mapcar #'car collection)
+                               nil
+                               'require-match)
+                      collection)))))
 
 (defun org-mru-clock--collect-history (history)
   "Turn HISTORY into a collection usable for `completing-read'.


### PR DESCRIPTION
The `#'helm-comp-read` function almost qworks with the default, but it does not
have kwargs for `:require match t` or the positional `nil` argument. This commit
adds a case for Helm completion in the switch.